### PR TITLE
Include unsupported key ID name in error message

### DIFF
--- a/src/ecdsa.rs
+++ b/src/ecdsa.rs
@@ -65,6 +65,9 @@ fn ensure_secp256k1_insecure_test_key_1(key_id: &EcdsaKeyId) {
         ic_cdk::trap("unsupported key ID curve");
     }
     if key_id.name.as_str() != "insecure_test_key_1" {
-        ic_cdk::trap(&format!("unsupported key ID name '{}'", key_id.name));
+        ic_cdk::trap(&format!(
+            "unsupported key ID name: expected 'insecure_test_key_1' but got '{}'",
+            key_id.name
+        ));
     }
 }

--- a/src/ecdsa.rs
+++ b/src/ecdsa.rs
@@ -65,6 +65,6 @@ fn ensure_secp256k1_insecure_test_key_1(key_id: &EcdsaKeyId) {
         ic_cdk::trap("unsupported key ID curve");
     }
     if key_id.name.as_str() != "insecure_test_key_1" {
-        ic_cdk::trap("unsupported key ID name");
+        ic_cdk::trap(&format!("unsupported key ID name '{}'", key_id.name));
     }
 }

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -162,6 +162,6 @@ fn ensure_bip340secp256k1_insecure_test_key_1(key_id: &SchnorrKeyId) {
         ic_cdk::trap("unsupported key ID algorithm");
     }
     if key_id.name.as_str() != "insecure_test_key_1" {
-        ic_cdk::trap("unsupported key ID name");
+        ic_cdk::trap(&format!("unsupported key ID name '{}'", key_id.name));
     }
 }

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -162,6 +162,9 @@ fn ensure_bip340secp256k1_insecure_test_key_1(key_id: &SchnorrKeyId) {
         ic_cdk::trap("unsupported key ID algorithm");
     }
     if key_id.name.as_str() != "insecure_test_key_1" {
-        ic_cdk::trap(&format!("unsupported key ID name '{}'", key_id.name));
+        ic_cdk::trap(&format!(
+            "unsupported key ID name: expected 'insecure_test_key_1' but got '{}'",
+            key_id.name
+        ));
     }
 }

--- a/src/vetkd.rs
+++ b/src/vetkd.rs
@@ -132,6 +132,6 @@ fn ensure_bls12_381_insecure_test_key_1(key_id: VetKDKeyId) {
         ic_cdk::trap("unsupported key ID curve");
     }
     if key_id.name.as_str() != "insecure_test_key_1" {
-        ic_cdk::trap("unsupported key ID name");
+        ic_cdk::trap(&format!("unsupported key ID name '{}'", key_id.name));
     }
 }

--- a/src/vetkd.rs
+++ b/src/vetkd.rs
@@ -132,6 +132,9 @@ fn ensure_bls12_381_insecure_test_key_1(key_id: VetKDKeyId) {
         ic_cdk::trap("unsupported key ID curve");
     }
     if key_id.name.as_str() != "insecure_test_key_1" {
-        ic_cdk::trap(&format!("unsupported key ID name '{}'", key_id.name));
+        ic_cdk::trap(&format!(
+            "unsupported key ID name: expected 'insecure_test_key_1' but got '{}'",
+            key_id.name
+        ));
     }
 }


### PR DESCRIPTION
Includes the submitted key ID name in the error message that a user gets when using an unsupported key ID name.