### PR TITLE
Switch to macos-15 in darwin github workflow

### DIFF
--- a/.github/workflows/chainkeys-testing-canister.yml
+++ b/.github/workflows/chainkeys-testing-canister.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   chainkeys-testing-canister-darwin:
-    runs-on: macos-12
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v1
       - name: Provision Darwin


### PR DESCRIPTION
Switches to macOS-15 for the darwin Github workflow, as [macos-12 is deprecated.](https://github.com/actions/runner-images/issues/10721).