### PR TITLE
add gzip to dfx json

### DIFF
--- a/.github/workflows/chainkeys-testing-canister.yml
+++ b/.github/workflows/chainkeys-testing-canister.yml
@@ -25,7 +25,7 @@ jobs:
           pocket-ic-server-version: "7.0.0"
       - name: Build chainkeys-testing-canister Darwin
         run: |
-          cargo build --target wasm32-unknown-unknown --release
+          dfx build --check
       - name: Lint chainkeys-testing-canister Darwin
         run: |
           cargo fmt --all -- --check && cargo clippy --all-targets --all-features -- -D warnings
@@ -44,7 +44,7 @@ jobs:
           pocket-ic-server-version: "7.0.0"
       - name: Build chainkeys-testing-canister Linux
         run: |
-          cargo build --target wasm32-unknown-unknown --release
+          dfx build --check
       - name: Lint chainkeys-testing-canister Linux
         run: |
           cargo fmt --all -- --check && cargo clippy --all-targets --all-features -- -D warnings

--- a/dfx.json
+++ b/dfx.json
@@ -3,7 +3,8 @@
     "chainkey_testing_canister": {
       "candid": "chainkey_testing_canister.did",
       "package": "chainkey_testing_canister",
-      "type": "rust"
+      "type": "rust",
+      "gzip": true
     }
   },
   "defaults": {


### PR DESCRIPTION
With this, `dfx build --check` generates `.dfx/local/canisters/chainkey_testing_canister/chainkey_testing_canister.wasm.gz` that can be published and used in other canisters as
```
    "chainkey-testing-canister": {
      "type": "custom",
      "candid": "https://github.com/dfinity/chainkey-testing-canister/releases/download/{tag}/chainkey-testing-canister.did",
      "wasm": "https://github.com/dfinity/chainkey-testing-canister/releases/download/{tag}/chainkey-testing-canister.wasm.gz"
    }
```