### PR TITLE
Adapt vetKD API to match expected production API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- **BREAKING**: Apply the [Minor renamings](https://github.com/dfinity/portal/pull/3763/commits/dff6e57af420780f09ef19bb3e0e2078347426d9) to the vetKD API.
+
+## [0.1.0] - 2024-12-18
+
+_Initial release._

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ All APIs support a single key ID: `insecure_test_key_1`.
  
 For the IDs of the test keys and production keys that are deployed on mainnet and distributed among subnet nodes, see [the Threshold signatures feature reference](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#key-derivation) in the Internet Computer developer docs.
 
-For the time being, no fees are charged. If canister usage becomes excessive, we will introduce fees but aim to keep these fees significantly lower than the [fees of the production APIs](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#api-fee). The community is invited to top up the canister with cycles.
+For the time being, no fees are charged. If canister usage becomes excessive, we will introduce fees but aim to keep these fees significantly lower than the [fees of the production APIs](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#api-fees). The community is invited to top up the canister with cycles.
 
 As this repository contains the canister's source code, developers can also deploy their own, private instance of this canister.
 

--- a/chainkey_testing_canister.did
+++ b/chainkey_testing_canister.did
@@ -8,7 +8,7 @@ type schnorr_algorithm = variant {
   ed25519;
 };
 
-type vetkd_curve = variant { bls12_381 };
+type vetkd_curve = variant { bls12_381_g2 };
 
 type ecdsa_public_key_args = record {
   canister_id : opt canister_id;
@@ -69,14 +69,14 @@ type vetkd_public_key_result = record {
   public_key : blob;
 };
 
-type vetkd_encrypted_key_args = record {
-  public_key_derivation_path : vec blob;
+type vetkd_derive_encrypted_key_args = record {
   derivation_id : blob;
-  key_id : record { curve : vetkd_curve; name : text };
   encryption_public_key : blob;
+  derivation_path : vec blob;
+  key_id : record { curve : vetkd_curve; name : text };
 };
 
-type vetkd_encrypted_key_result = record {
+type vetkd_derive_encrypted_key_result = record {
   encrypted_key : blob;
 };
 
@@ -95,7 +95,7 @@ service : {
 
   // Threshold key derivation
   vetkd_public_key : (vetkd_public_key_args) -> (vetkd_public_key_result);
-  vetkd_encrypted_key : (vetkd_encrypted_key_args) -> (vetkd_encrypted_key_result);
+  vetkd_derive_encrypted_key : (vetkd_derive_encrypted_key_args) -> (vetkd_derive_encrypted_key_result);
 
   // Statistics: call counts
   call_counts : () -> (call_counts_result);

--- a/src/vetkd.rs
+++ b/src/vetkd.rs
@@ -85,15 +85,15 @@ async fn vetkd_public_key(request: VetKDPublicKeyRequest) -> VetKDPublicKeyReply
 }
 
 #[update]
-async fn vetkd_derive_encrypted_key(request: VetKDDeriveEncryptedKeyRequest) -> VetKDDeriveEncryptedKeyReply {
+async fn vetkd_derive_encrypted_key(
+    request: VetKDDeriveEncryptedKeyRequest,
+) -> VetKDDeriveEncryptedKeyReply {
     inc_call_count("vetkd_derive_encrypted_key".to_string());
     ensure_call_is_paid(0);
     ensure_bls12_381_g2_insecure_test_key_1(request.key_id);
     ensure_derivation_path_is_valid(&request.derivation_path);
-    let derivation_path = DerivationPath::new(
-        ic_cdk::caller().as_slice(),
-        &request.derivation_path,
-    );
+    let derivation_path =
+        DerivationPath::new(ic_cdk::caller().as_slice(), &request.derivation_path);
     let tpk =
         TransportPublicKey::deserialize(&request.encryption_public_key).unwrap_or_else(
             |e| match e {

--- a/src/vetkd.rs
+++ b/src/vetkd.rs
@@ -17,8 +17,9 @@ pub type CanisterId = Principal;
 
 #[derive(CandidType, Clone, Deserialize, Eq, PartialEq)]
 pub enum VetKDCurve {
-    #[serde(rename = "bls12_381")]
-    Bls12_381,
+    #[serde(rename = "bls12_381_g2")]
+    #[allow(non_camel_case_types)]
+    Bls12_381_G2,
 }
 
 #[derive(CandidType, Clone, Deserialize, Eq, PartialEq)]
@@ -40,15 +41,15 @@ pub struct VetKDPublicKeyReply {
 }
 
 #[derive(CandidType, Deserialize)]
-pub struct VetKDEncryptedKeyRequest {
-    pub public_key_derivation_path: Vec<Vec<u8>>,
+pub struct VetKDDeriveEncryptedKeyRequest {
     pub derivation_id: Vec<u8>,
-    pub key_id: VetKDKeyId,
     pub encryption_public_key: Vec<u8>,
+    pub derivation_path: Vec<Vec<u8>>,
+    pub key_id: VetKDKeyId,
 }
 
 #[derive(CandidType, Deserialize)]
-pub struct VetKDEncryptedKeyReply {
+pub struct VetKDDeriveEncryptedKeyReply {
     pub encrypted_key: Vec<u8>,
 }
 
@@ -71,7 +72,7 @@ lazy_static::lazy_static! {
 #[update]
 async fn vetkd_public_key(request: VetKDPublicKeyRequest) -> VetKDPublicKeyReply {
     inc_call_count("vetkd_public_key".to_string());
-    ensure_bls12_381_insecure_test_key_1(request.key_id);
+    ensure_bls12_381_g2_insecure_test_key_1(request.key_id);
     ensure_derivation_path_is_valid(&request.derivation_path);
     let derivation_path = {
         let canister_id = request.canister_id.unwrap_or_else(ic_cdk::caller);
@@ -84,14 +85,14 @@ async fn vetkd_public_key(request: VetKDPublicKeyRequest) -> VetKDPublicKeyReply
 }
 
 #[update]
-async fn vetkd_encrypted_key(request: VetKDEncryptedKeyRequest) -> VetKDEncryptedKeyReply {
-    inc_call_count("vetkd_encrypted_key".to_string());
+async fn vetkd_derive_encrypted_key(request: VetKDDeriveEncryptedKeyRequest) -> VetKDDeriveEncryptedKeyReply {
+    inc_call_count("vetkd_derive_encrypted_key".to_string());
     ensure_call_is_paid(0);
-    ensure_bls12_381_insecure_test_key_1(request.key_id);
-    ensure_derivation_path_is_valid(&request.public_key_derivation_path);
+    ensure_bls12_381_g2_insecure_test_key_1(request.key_id);
+    ensure_derivation_path_is_valid(&request.derivation_path);
     let derivation_path = DerivationPath::new(
         ic_cdk::caller().as_slice(),
-        &request.public_key_derivation_path,
+        &request.derivation_path,
     );
     let tpk =
         TransportPublicKey::deserialize(&request.encryption_public_key).unwrap_or_else(
@@ -122,13 +123,13 @@ async fn vetkd_encrypted_key(request: VetKDEncryptedKeyRequest) -> VetKDEncrypte
     )
     .unwrap_or_else(|_e| ic_cdk::trap("bad key share"));
 
-    VetKDEncryptedKeyReply {
+    VetKDDeriveEncryptedKeyReply {
         encrypted_key: ek.serialize().to_vec(),
     }
 }
 
-fn ensure_bls12_381_insecure_test_key_1(key_id: VetKDKeyId) {
-    if key_id.curve != VetKDCurve::Bls12_381 {
+fn ensure_bls12_381_g2_insecure_test_key_1(key_id: VetKDKeyId) {
+    if key_id.curve != VetKDCurve::Bls12_381_G2 {
         ic_cdk::trap("unsupported key ID curve");
     }
     if key_id.name.as_str() != "insecure_test_key_1" {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -246,7 +246,7 @@ fn should_consistently_derive_vetkey() {
         .expect("failed to create transport secret key");
     let encrypted_key_2 = canister
         .vetkd_derive_encrypted_key(VetKDDeriveEncryptedKeyRequest {
-            derivation_path: derivation_path,
+            derivation_path,
             derivation_id: derivation_id.clone(),
             encryption_public_key: tsk_2.public_key(),
             key_id,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,8 +16,8 @@ use chainkey_testing_canister::schnorr::SchnorrPublicKeyResult;
 use chainkey_testing_canister::schnorr::SignWithSchnorrArgs;
 use chainkey_testing_canister::schnorr::SignWithSchnorrResult;
 use chainkey_testing_canister::vetkd::VetKDCurve;
-use chainkey_testing_canister::vetkd::VetKDEncryptedKeyReply;
-use chainkey_testing_canister::vetkd::VetKDEncryptedKeyRequest;
+use chainkey_testing_canister::vetkd::VetKDDeriveEncryptedKeyReply;
+use chainkey_testing_canister::vetkd::VetKDDeriveEncryptedKeyRequest;
 use chainkey_testing_canister::vetkd::VetKDKeyId;
 use chainkey_testing_canister::vetkd::VetKDPublicKeyReply;
 use chainkey_testing_canister::vetkd::VetKDPublicKeyRequest;
@@ -215,7 +215,7 @@ fn should_consistently_derive_vetkey() {
 
     let derivation_path = vec!["test-derivation-path".as_bytes().to_vec()];
     let key_id = VetKDKeyId {
-        curve: VetKDCurve::Bls12_381,
+        curve: VetKDCurve::Bls12_381_G2,
         name: "insecure_test_key_1".to_string(),
     };
     let derivation_id = b"test-derivation-id".to_vec();
@@ -231,8 +231,8 @@ fn should_consistently_derive_vetkey() {
     let tsk_1 = TransportSecretKey::from_seed([101; 32].to_vec())
         .expect("failed to create transport secret key");
     let encrypted_key_1 = canister
-        .vetkd_encrypted_key(VetKDEncryptedKeyRequest {
-            public_key_derivation_path: derivation_path.clone(),
+        .vetkd_derive_encrypted_key(VetKDDeriveEncryptedKeyRequest {
+            derivation_path: derivation_path.clone(),
             derivation_id: derivation_id.clone(),
             encryption_public_key: tsk_1.public_key(),
             key_id: key_id.clone(),
@@ -245,8 +245,8 @@ fn should_consistently_derive_vetkey() {
     let tsk_2 = TransportSecretKey::from_seed([102; 32].to_vec())
         .expect("failed to create transport secret key");
     let encrypted_key_2 = canister
-        .vetkd_encrypted_key(VetKDEncryptedKeyRequest {
-            public_key_derivation_path: derivation_path,
+        .vetkd_derive_encrypted_key(VetKDDeriveEncryptedKeyRequest {
+            derivation_path: derivation_path,
             derivation_id: derivation_id.clone(),
             encryption_public_key: tsk_2.public_key(),
             key_id,
@@ -368,8 +368,8 @@ impl CanisterSetup {
         }
     }
 
-    pub fn vetkd_encrypted_key(&self, args: VetKDEncryptedKeyRequest) -> VetKDEncryptedKeyReply {
-        let method = "vetkd_encrypted_key";
+    pub fn vetkd_derive_encrypted_key(&self, args: VetKDDeriveEncryptedKeyRequest) -> VetKDDeriveEncryptedKeyReply {
+        let method = "vetkd_derive_encrypted_key";
         let result = self.env.update_call(
             self.canister_id,
             Principal::anonymous(),
@@ -378,7 +378,7 @@ impl CanisterSetup {
         );
         match result {
             Ok(WasmResult::Reply(bytes)) => {
-                Decode!(&bytes, VetKDEncryptedKeyReply).expect("failed to decode {method} result")
+                Decode!(&bytes, VetKDDeriveEncryptedKeyReply).expect("failed to decode {method} result")
             }
             Ok(WasmResult::Reject(error)) => {
                 panic!("canister rejected call to {method}: {error}")

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -368,7 +368,10 @@ impl CanisterSetup {
         }
     }
 
-    pub fn vetkd_derive_encrypted_key(&self, args: VetKDDeriveEncryptedKeyRequest) -> VetKDDeriveEncryptedKeyReply {
+    pub fn vetkd_derive_encrypted_key(
+        &self,
+        args: VetKDDeriveEncryptedKeyRequest,
+    ) -> VetKDDeriveEncryptedKeyReply {
         let method = "vetkd_derive_encrypted_key";
         let result = self.env.update_call(
             self.canister_id,
@@ -377,9 +380,8 @@ impl CanisterSetup {
             Encode!(&args).expect("failed to encode args"),
         );
         match result {
-            Ok(WasmResult::Reply(bytes)) => {
-                Decode!(&bytes, VetKDDeriveEncryptedKeyReply).expect("failed to decode {method} result")
-            }
+            Ok(WasmResult::Reply(bytes)) => Decode!(&bytes, VetKDDeriveEncryptedKeyReply)
+                .expect("failed to decode {method} result"),
             Ok(WasmResult::Reject(error)) => {
                 panic!("canister rejected call to {method}: {error}")
             }


### PR DESCRIPTION
Adapts the vetKD API to match the API that is expected to be used in production. In particular, adapts the API according to the changes made in https://github.com/dfinity/portal/pull/3763/commits/dff6e57af420780f09ef19bb3e0e2078347426d9 in the PR the specifies the vetKD API.