### PR TITLE
chore(ci): update ubuntu version and cleanup provisioning files

### DIFF
--- a/.github/workflows/chainkeys-testing-canister.yml
+++ b/.github/workflows/chainkeys-testing-canister.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           cargo test
   chainkeys-testing-canister-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v1
       - name: Provision Linux

--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -5,20 +5,9 @@ set -ex
 # Enter temporary directory.
 pushd /tmp
 
-# Install Homebrew
-curl --location --output install-brew.sh "https://raw.githubusercontent.com/Homebrew/install/master/install.sh"
-bash install-brew.sh
-rm install-brew.sh
-
-# Install Node.
-version=${NODE_VERSION:=14.21.3}
-curl --location --output node.pkg "https://nodejs.org/dist/v$version/node-v$version.pkg"
-sudo installer -pkg node.pkg -store -target /
-rm node.pkg
-
 # Install DFINITY SDK.
 curl --location --output install-dfx.sh "https://raw.githubusercontent.com/dfinity/sdk/master/public/install-dfxvm.sh"
-DFX_VERSION=${DFX_VERSION:=0.24.1} DFXVM_INIT_YES=true bash install-dfx.sh
+DFX_VERSION=${DFX_VERSION:=0.25.0} DFXVM_INIT_YES=true bash install-dfx.sh
 rm install-dfx.sh
 echo "$HOME/Library/Application Support/org.dfinity.dfx/bin" >> $GITHUB_PATH
 source "$HOME/Library/Application Support/org.dfinity.dfx/env"
@@ -37,44 +26,8 @@ if [ -f "${GITHUB_WORKSPACE}/.ic-commit" ]; then
     fi
 fi
 
-# Install ic-repl
-version=0.7.0
-curl --location --output ic-repl "https://github.com/chenyan2002/ic-repl/releases/download/$version/ic-repl-macos"
-mv ./ic-repl /usr/local/bin/ic-repl
-chmod a+x /usr/local/bin/ic-repl
-
-# Install cmake
-brew install cmake
-
-# Install rust
-curl --location --output install-rustup.sh "https://sh.rustup.rs"
-bash install-rustup.sh -y
+# Add wasm32 Rust target
 rustup target add wasm32-unknown-unknown
-
-# Install matchers
-matchers_version=1.2.0
-curl -fsSLO "https://github.com/kritzcreek/motoko-matchers/archive/refs/tags/v${matchers_version}.tar.gz" 
-tar -xzf "v${matchers_version}.tar.gz" --directory "$(dfx cache show)"
-rm "v${matchers_version}.tar.gz"
-mv "$(dfx cache show)/motoko-matchers-${matchers_version}" "$(dfx cache show)/motoko-matchers"
-
-# Install wasmtime
-wasmtime_version=0.33.1
-curl -fsSLO "https://github.com/bytecodealliance/wasmtime/releases/download/v${wasmtime_version}/wasmtime-v${wasmtime_version}-x86_64-macos.tar.xz" 
-mkdir -p "${HOME}/bin"
-tar -xf "wasmtime-v${wasmtime_version}-x86_64-macos.tar.xz" --directory "${HOME}/bin/"
-mv "${HOME}/bin/wasmtime-v${wasmtime_version}-x86_64-macos/wasmtime" "${HOME}/bin/wasmtime"
-rm "wasmtime-v${wasmtime_version}-x86_64-macos.tar.xz"
-
-# Install wasi2ic
-git clone https://github.com/wasm-forge/wasi2ic
-cargo install --path wasi2ic --root "${HOME}"
-
-# Install wasm-opt
-version=117
-curl -fsSLO "https://github.com/WebAssembly/binaryen/releases/download/version_117/binaryen-version_${version}-x86_64-macos.tar.gz" 
-tar -xzf "binaryen-version_${version}-x86_64-macos.tar.gz" --directory "${HOME}/" --strip-components 1
-rm "binaryen-version_${version}-x86_64-macos.tar.gz"
 
 # Exit temporary directory.
 popd

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -5,19 +5,14 @@ set -ex
 # Enter temporary directory.
 pushd /tmp
 
-# Install Node.
-wget --output-document install-node.sh "https://deb.nodesource.com/setup_14.x"
-sudo bash install-node.sh
-sudo apt-get install --yes nodejs
-rm install-node.sh
-
 # Install DFINITY SDK.
 wget --output-document install-dfx.sh "https://raw.githubusercontent.com/dfinity/sdk/master/public/install-dfxvm.sh"
-DFX_VERSION=${DFX_VERSION:=0.24.1} DFXVM_INIT_YES=true bash install-dfx.sh
+DFX_VERSION=${DFX_VERSION:=0.25.0} DFXVM_INIT_YES=true bash install-dfx.sh
 rm install-dfx.sh
 echo "$HOME/.local/share/dfx/bin" >> $GITHUB_PATH
 source "$HOME/.local/share/dfx/env"
 dfx cache install
+
 # check the current ic-commit found in the main branch, check if it differs from the one in this PR branch
 # if so, update the  dfx cache with the latest ic artifacts
 if [ -f "${GITHUB_WORKSPACE}/.ic-commit" ]; then
@@ -31,48 +26,8 @@ if [ -f "${GITHUB_WORKSPACE}/.ic-commit" ]; then
     fi
 fi
 
-# Install ic-repl
-version=0.7.0
-curl --location --output ic-repl "https://github.com/chenyan2002/ic-repl/releases/download/$version/ic-repl-linux64"
-mv ./ic-repl /usr/local/bin/ic-repl
-chmod a+x /usr/local/bin/ic-repl
-
-# Install cmake
-sudo apt-get install --yes cmake
-
-# Install rust
-wget --output-document install-rustup.sh "https://sh.rustup.rs"
-sudo bash install-rustup.sh -y
+# Add wasm32 Rust target
 rustup target add wasm32-unknown-unknown
-
-# Install matchers
-matchers_version=1.2.0
-curl -fsSLO "https://github.com/kritzcreek/motoko-matchers/archive/refs/tags/v${matchers_version}.tar.gz" 
-tar -xzf "v${matchers_version}.tar.gz" --directory "$(dfx cache show)"
-rm "v${matchers_version}.tar.gz"
-mv "$(dfx cache show)/motoko-matchers-${matchers_version}" "$(dfx cache show)/motoko-matchers"
-
-# Install wasmtime
-wasmtime_version=0.33.1
-curl -fsSLO "https://github.com/bytecodealliance/wasmtime/releases/download/v${wasmtime_version}/wasmtime-v${wasmtime_version}-x86_64-linux.tar.xz" 
-mkdir -p "${HOME}/bin"
-tar -xf "wasmtime-v${wasmtime_version}-x86_64-linux.tar.xz" --directory "${HOME}/bin/"
-mv "${HOME}/bin/wasmtime-v${wasmtime_version}-x86_64-linux/wasmtime" "${HOME}/bin/wasmtime"
-rm "wasmtime-v${wasmtime_version}-x86_64-linux.tar.xz"
-
-# Install wasi2ic
-git clone https://github.com/wasm-forge/wasi2ic
-cargo install --path wasi2ic --root "${HOME}"
-
-# Install wasm-opt
-version=117
-curl -fsSLO "https://github.com/WebAssembly/binaryen/releases/download/version_117/binaryen-version_${version}-x86_64-linux.tar.gz" 
-tar -xzf "binaryen-version_${version}-x86_64-linux.tar.gz" --directory "${HOME}/" --strip-components 1
-rm "binaryen-version_${version}-x86_64-linux.tar.gz"
-
-# Set environment variables.
-echo "$HOME/bin" >> $GITHUB_PATH
-echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
 # Exit temporary directory.
 popd


### PR DESCRIPTION
ubuntu-20.04 Github actions image is unsupported as of 2025-04-15, so it is updated to the current ubuntu-24.04. Also removes all unnecessary components from the provisioning files. Note that a recent version of the Rust toolchain is available in GitHub-hosted runners by default (i.e., it doesn't need to be installed explicitly).