### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/chainkeys-testing-canister.yml
+++ b/.github/workflows/chainkeys-testing-canister.yml
@@ -16,7 +16,7 @@ jobs:
   chainkeys-testing-canister-darwin:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Build chainkeys-testing-canister Darwin
@@ -31,7 +31,7 @@ jobs:
   chainkeys-testing-canister-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Build chainkeys-testing-canister Linux


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v1` -> `actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0`
  - Version: v1.2.0 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/50fbc622fc4ef5163becd7fab6573eac35f8462e


### Files modified

- `.github/workflows/chainkeys-testing-canister.yml`